### PR TITLE
Implement HK monitor reference app

### DIFF
--- a/Final Project/project-plan.md
+++ b/Final Project/project-plan.md
@@ -1,0 +1,87 @@
+# HK Conditions Monitor – Project Plan
+
+This plan turns the initial concept (console-first monitoring toolkit for HKO/EPD/TD data) into a concrete roadmap for a 6-person team over ~3 weeks.
+
+## 1. Assumptions & Scope
+- **Language:** Python 3.10+.
+- **Runtime:** Console/CLI demo; no web UI.
+- **APIs to showcase:**
+  - Hong Kong Observatory (HKO) warnings summary.
+  - HKO rainfall nowcast by district.
+  - Environmental Protection Department (EPD) AQHI feed.
+  - Transport Department disruption summaries.
+- **Infra:** Local execution, SQLite for persistence, optional Telegram alerts (mocked when token missing).
+- **Deliverables:** Running CLI demo, Telegram alert screenshot/logs, architecture/dataflow diagrams, short report/slides.
+
+## 2. Architecture Overview
+```
+config.toml/.env  →  config.py  →  shared settings & secrets
+                       ↓
+collector.py  →  db.py (SQLite)  →  tables: warnings, rain, aqhi, traffic
+                       ↓
+alerts.py  →  Telegram/console notifications on state changes
+                       ↓
+app.py CLI  →  prints latest tiles, accepts simple user input
+```
+**Supporting modules:** `utils/logging.py`, `tests/` (unit tests + demo scripts), `tests/data/` (mock JSON payloads).
+
+### Module responsibilities
+| Module | Responsibilities |
+| --- | --- |
+| `config.py` | Load config, validate required keys (API endpoints, polling interval, district list, Telegram token/chat). |
+| `db.py` | Initialize SQLite schema, insert snapshots, fetch previous/current rows, expose query helpers per metric. |
+| `collector.py` | Poll each API, normalize payloads into canonical dicts, persist into DB, handle network failures + caching fallback. |
+| `alerts.py` | Compare consecutive snapshots, map values into severity buckets, send alerts via Telegram or console fallback, dedupe events. |
+| `app.py` | CLI wrapper: choose district/station, show latest snapshot per tile, refresh view, print timestamps. |
+| `tests/` | Unit tests for parsers & change detection plus demo scripts simulating notable scenarios. |
+
+## 3. Work Packages
+1. **Environment & Scaffolding**
+   - Repo structure (`src/` or flat), `requirements.txt`, `.env`/`config.template.toml`, logging defaults.
+2. **API Research & Mock Data**
+   - Confirm endpoints, auth, rate limits; store 2–3 JSON samples per API inside `tests/data/`; document category mappings.
+3. **Database Schema & Data Model**
+   - Define tables (`warnings`, `rain`, `aqhi`, `traffic`) with timestamps + district/station columns; implement `db.py` helpers.
+4. **Collector Implementation**
+   - Functions: `fetch_warnings`, `fetch_rain`, `fetch_aqhi`, `fetch_traffic`; normalization; persistence; retry/fallback strategy.
+5. **Alerts & Telegram Integration**
+   - Change detection engine, severity mapping per metric, Telegram wrapper (HTTP bot API) w/ dry-run console output.
+6. **CLI Demo (`app.py`)**
+   - Render four tiles + last updated timestamps; allow district/station selection; refresh action; highlight active alerts.
+7. **Testing & Demo Scripts**
+   - Pytest/unit tests for parsers, category mapping, and change detection; scenario scripts: warning upgrade, AQHI spike, traffic incident.
+8. **Slides/Report**
+   - Architecture/dataflow diagrams, screenshots (CLI, Telegram), summary of libraries, lessons learned.
+
+## 4. Team Roles & Ownership
+| Role | Focus | Key Deliverables |
+| --- | --- | --- |
+| **Dev A – Tech Lead / Integrator** | Repo scaffolding, integration, logging | Project skeleton, CI instructions, final integration fixes |
+| **Dev B – API & Collector Lead** | Endpoint research, fetchers, mocks | API docs, mock payloads, working collectors |
+| **Dev C – DB & Modeling** | Schema design, `db.py` implementation | Schema doc, migration/init script, CRUD helpers |
+| **Dev D – Alerts & Telegram** | Change detection, alert delivery | Severity mapping, alert engine, Telegram client |
+| **Dev E – CLI & Testing** | User-facing CLI, unit tests, demo scripts | `app.py`, pytest suite, scenario scripts |
+| **Dev F – PM / Docs** | Coordination, slides/report, presentation prep | Meeting notes, diagrams, slide deck, demo choreography |
+
+## 5. Timeline & Meetings (3-week window)
+| Week | Meeting | Objectives |
+| --- | --- | --- |
+| Week 1, Day 0 | **Kickoff & Architecture (60–90 min)** | Confirm scope, assign roles, agree on tech stack & repo rules. |
+| Week 1, Day 3–4 | **API & Schema Review (45–60 min)** | Freeze API mappings, DB schema, category values. |
+| Week 2, Day 7–8 | **Mid-project Integration (60–90 min)** | Run collector → DB → CLI flow; identify integration bugs. |
+| Week 2, Day 11–12 | **Feature Freeze & Test Plan (45–60 min)** | Declare feature freeze, prioritize bugfixes, lock demo scenarios. |
+| Week 3, Day 14–15 | **Full Rehearsal (60–90 min)** | Dry-run slides + live demo + Telegram alert; finalize presenters. |
+
+## 6. Immediate Action Items
+1. **Repo skeleton:** Dev A creates structure, `requirements.txt`, config templates, logging baseline.
+2. **Role confirmation:** Map real team members to Dev A–F in `README` or `docs/owners.md`.
+3. **Schedule meetings:** Put all five meetings on the calendar.
+4. **Parallel kick-off:** Dev B starts API docs + mock payload collection; Dev C drafts schema + `db.py` stubs.
+5. **Deliverable shell:** Dev F creates slide outline (Problem → Solution → Architecture → Demo → Lessons) so assets can drop in later.
+
+## 7. Success Criteria
+- CLI demo shows four tiles with recent data + timestamps.
+- Alerts trigger only on state/category transitions and demonstrate via Telegram or console log.
+- SQLite DB stores snapshots and allows quick retrieval of latest + previous states per metric.
+- Mock datasets enable offline demos when APIs are unreachable.
+- Presentation includes diagrams, screenshots, and a narrated demo path tested in rehearsal.

--- a/hk_monitor/README.md
+++ b/hk_monitor/README.md
@@ -1,0 +1,37 @@
+# HK Conditions Monitor
+
+This folder contains the reference implementation described in `Final Project/project-plan.md`.  It can run entirely on mock data for demos or switch to the real Hong Kong open-data APIs by setting `use_mock_data = false` in `config.toml`.
+
+## Getting started
+
+```bash
+cd hk_monitor
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp config.template.toml config.toml
+```
+
+Adjust the config to point to your preferred district/station and optionally set the Telegram bot token/chat ID.
+
+## Typical workflows
+
+* **Collect data once and show the CLI tiles**
+
+  ```bash
+  python -m hk_monitor.app --config config.toml --collect
+  ```
+
+* **Trigger alerts after running the collector**
+
+  ```bash
+  python -m hk_monitor.app --config config.toml --collect --alerts
+  ```
+
+* **Run the automated tests**
+
+  ```bash
+  pytest
+  ```
+
+The project defaults to the bundled mock JSON payloads so everything works offline.

--- a/hk_monitor/__init__.py
+++ b/hk_monitor/__init__.py
@@ -1,0 +1,1 @@
+"""HK Conditions Monitor package."""

--- a/hk_monitor/alerts.py
+++ b/hk_monitor/alerts.py
@@ -1,0 +1,130 @@
+"""Change detection and alert routing."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+import logging
+import sqlite3
+import requests
+
+from .config import Config
+from . import db
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class AlertMessage:
+    metric: str
+    previous: str
+    current: str
+    description: str
+
+    def format(self) -> str:
+        header = f"[{self.metric.upper()}] {self.previous} -> {self.current}"
+        return f"{header}\n{self.description}"
+
+
+class TelegramClient:
+    """Minimal Telegram sender wrapping the HTTP Bot API."""
+
+    def __init__(self, token: str, chat_id: str, enabled: bool, test_mode: bool = False):
+        self.token = token
+        self.chat_id = chat_id
+        self.enabled = enabled
+        self.test_mode = test_mode
+
+    def send(self, message: AlertMessage) -> None:
+        payload = {"chat_id": self.chat_id, "text": message.format()}
+        if not self.enabled or self.test_mode:
+            logger.info("[DRY RUN] %s", payload["text"])
+            print(payload["text"])  # pragma: no cover - CLI feedback
+            return
+        response = requests.post(
+            f"https://api.telegram.org/bot{self.token}/sendMessage",
+            timeout=10,
+            json=payload,
+        )
+        response.raise_for_status()
+
+
+class ChangeDetector:
+    def __init__(self, conn: sqlite3.Connection, messenger: TelegramClient):
+        self.conn = conn
+        self.messenger = messenger
+        self.table_config: Dict[str, Callable[[sqlite3.Row], AlertMessage]] = {
+            "warnings": self._format_warning,
+            "rain": self._format_rain,
+            "aqhi": self._format_aqhi,
+            "traffic": self._format_traffic,
+        }
+
+    def run(self) -> None:
+        for table, formatter in self.table_config.items():
+            rows = db.get_last_two(self.conn, table)
+            if len(rows) < 2:
+                continue
+            previous, current = rows[1], rows[0]
+            if _extract_category(previous) == _extract_category(current):
+                continue
+            alert = formatter(current)
+            alert.previous = _extract_category(previous)
+            alert.current = _extract_category(current)
+            self.messenger.send(alert)
+
+    def _format_warning(self, row: sqlite3.Row) -> AlertMessage:
+        return AlertMessage(
+            metric="Warnings",
+            previous=row["level"],
+            current=row["level"],
+            description=row["message"],
+        )
+
+    def _format_rain(self, row: sqlite3.Row) -> AlertMessage:
+        description = f"{row['district']}: {row['intensity']}"
+        return AlertMessage(
+            metric="Rain",
+            previous=row["intensity"],
+            current=row["intensity"],
+            description=description,
+        )
+
+    def _format_aqhi(self, row: sqlite3.Row) -> AlertMessage:
+        description = f"{row['station']} AQHI {row['value']:.1f}"
+        return AlertMessage(
+            metric="AQHI",
+            previous=row["category"],
+            current=row["category"],
+            description=description,
+        )
+
+    def _format_traffic(self, row: sqlite3.Row) -> AlertMessage:
+        return AlertMessage(
+            metric="Traffic",
+            previous=row["severity"],
+            current=row["severity"],
+            description=row["description"],
+        )
+
+
+def run_alerts(config: Config) -> None:
+    from .db import connect
+
+    with connect(config.app.database_path) as conn:
+        messenger = TelegramClient(
+            token=config.telegram.bot_token,
+            chat_id=config.telegram.chat_id,
+            enabled=config.telegram.enabled,
+            test_mode=config.telegram.test_mode,
+        )
+        ChangeDetector(conn, messenger).run()
+
+
+def _extract_category(row: sqlite3.Row) -> str:
+    for key in ("category", "level", "intensity", "severity"):
+        if key in row.keys():
+            return str(row[key])
+    return ""
+
+
+__all__ = ["run_alerts", "ChangeDetector", "TelegramClient", "AlertMessage"]

--- a/hk_monitor/app.py
+++ b/hk_monitor/app.py
@@ -1,0 +1,90 @@
+"""Console demo for the HK Conditions Monitor."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+from typing import Dict, Optional
+
+from . import collector, alerts, db
+from .config import Config
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s - %(message)s")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="HK Conditions Monitor CLI")
+    parser.add_argument(
+        "--config",
+        default="config.toml",
+        help="Path to the TOML configuration file (default: config.toml)",
+    )
+    parser.add_argument(
+        "--collect",
+        action="store_true",
+        help="Fetch metrics once before showing the dashboard.",
+    )
+    parser.add_argument(
+        "--alerts",
+        action="store_true",
+        help="Run change detection and emit alerts after refreshing data.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = Config.load(args.config)
+
+    with db.connect(config.app.database_path) as conn:
+        if args.collect:
+            logging.info("Collecting new data snapshot...")
+            collector.collect_once(config, conn)
+        snapshot = db.get_latest(conn)
+        _print_snapshot(snapshot)
+
+    if args.alerts:
+        logging.info("Running change detection after snapshot update...")
+        alerts.run_alerts(config)
+
+
+def _print_snapshot(snapshot: Dict[str, Optional[sqlite3.Row]]) -> None:
+    def format_warning(row: Optional[sqlite3.Row]) -> str:
+        if not row:
+            return "No warning data."
+        return f"Level: {row['level']}\nMessage: {row['message']}\nUpdated: {row['updated_at']}"
+
+    def format_rain(row: Optional[sqlite3.Row]) -> str:
+        if not row:
+            return "No rain data."
+        return f"District: {row['district']}\nIntensity: {row['intensity']}\nUpdated: {row['updated_at']}"
+
+    def format_aqhi(row: Optional[sqlite3.Row]) -> str:
+        if not row:
+            return "No AQHI data."
+        return (
+            f"Station: {row['station']}\nCategory: {row['category']}\n"
+            f"Value: {row['value']:.1f}\nUpdated: {row['updated_at']}"
+        )
+
+    def format_traffic(row: Optional[sqlite3.Row]) -> str:
+        if not row:
+            return "No traffic data."
+        return f"Severity: {row['severity']}\n{row['description']}\nUpdated: {row['updated_at']}"
+
+    sections = [
+        ("Warnings", format_warning(snapshot.get("warnings"))),
+        ("Rain", format_rain(snapshot.get("rain"))),
+        ("AQHI", format_aqhi(snapshot.get("aqhi"))),
+        ("Traffic", format_traffic(snapshot.get("traffic"))),
+    ]
+
+    separator = "\n" + "=" * 60 + "\n"
+    output_lines = []
+    for title, body in sections:
+        output_lines.append(f"{title}\n{'-' * len(title)}\n{body}")
+    print(separator.join(output_lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/hk_monitor/collector.py
+++ b/hk_monitor/collector.py
@@ -1,0 +1,198 @@
+"""Data collectors for HK public data feeds."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Dict
+import sqlite3
+
+import requests
+
+from . import db
+from .config import Config
+
+ISO_VARIANTS = ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ")
+
+
+def collect_once(
+    config: Config, conn: sqlite3.Connection | None = None
+) -> Dict[str, sqlite3.Row | None]:
+    """Fetch all metrics once and persist them into SQLite."""
+    if conn is None:
+        from .db import connect
+
+        with connect(config.app.database_path) as connection:
+            _collect(config, connection)
+            return db.get_latest(connection)
+    else:
+        _collect(config, conn)
+        return db.get_latest(conn)
+
+
+def _collect(config: Config, conn: sqlite3.Connection) -> None:
+    warning_record = fetch_warning(config)
+    if warning_record:
+        db.save_warning(conn, warning_record)
+
+    rain_record = fetch_rain(config)
+    if rain_record:
+        db.save_rain(conn, rain_record)
+
+    aqhi_record = fetch_aqhi(config)
+    if aqhi_record:
+        db.save_aqhi(conn, aqhi_record)
+
+    traffic_record = fetch_traffic(config)
+    if traffic_record:
+        db.save_traffic(conn, traffic_record)
+
+
+def fetch_warning(config: Config) -> db.WarningRecord | None:
+    data = _get_payload(
+        config, config.api.warnings_url, config.mocks.warnings, key="warnings"
+    )
+    details = data.get("details") or data.get("warning") or []
+    if not details:
+        return None
+    chosen = details[0]
+    timestamp = _parse_time(
+        chosen.get("updateTime") or data.get("updateTime")
+    )
+    return db.WarningRecord(
+        level=chosen.get("warningStatementCode", "UNKNOWN"),
+        message=chosen.get("warningMessage", "No warning message supplied."),
+        updated_at=timestamp,
+    )
+
+
+def fetch_rain(config: Config) -> db.RainRecord | None:
+    data = _get_payload(
+        config, config.api.rainfall_url, config.mocks.rainfall, key="rainfall"
+    )
+    if "data" in data:
+        rainfall_data = data.get("data", [])
+    else:
+        rainfall_data = (data.get("rainfall") or {}).get("data", [])
+    district_entry = next(
+        (row for row in rainfall_data if row.get("place") == config.app.rain_district),
+        None,
+    )
+    if not district_entry:
+        return None
+    value = float(district_entry.get("max", district_entry.get("value", 0)) or 0)
+    return db.RainRecord(
+        district=config.app.rain_district,
+        intensity=_categorize_rain(value),
+        updated_at=_parse_time(district_entry.get("recordTime") or data.get("updateTime")),
+    )
+
+
+def fetch_aqhi(config: Config) -> db.AqhiRecord | None:
+    data = _get_payload(config, config.api.aqhi_url, config.mocks.aqhi, key="aqhi")
+    if isinstance(data, list):
+        stations = data
+    else:
+        stations = data.get("aqhi") or data.get("data") or []
+    station_entry = next(
+        (row for row in stations if row.get("station") == config.app.aqhi_station),
+        None,
+    )
+    if not station_entry:
+        return None
+    value = float(station_entry.get("aqhi", station_entry.get("value", 0)) or 0)
+    return db.AqhiRecord(
+        station=config.app.aqhi_station,
+        category=_categorize_aqhi(value),
+        value=value,
+        updated_at=_parse_time(station_entry.get("time") or data.get("updateTime")),
+    )
+
+
+def fetch_traffic(config: Config) -> db.TrafficRecord | None:
+    data = _get_payload(
+        config, config.api.traffic_url, config.mocks.traffic, key="trafficnews"
+    )
+    if isinstance(data, list):
+        incidents = data
+    else:
+        incidents = data.get("trafficnews") or data.get("incidents") or []
+    entry = next(
+        (row for row in incidents if config.app.traffic_region in row.get("region", "")),
+        None,
+    )
+    if not entry:
+        return None
+    severity = entry.get("severity", entry.get("category", "info"))
+    description = entry.get("content") or entry.get("summary") or "Traffic update"
+    return db.TrafficRecord(
+        severity=severity.title(),
+        description=description.strip(),
+        updated_at=_parse_time(entry.get("update_time") or data.get("updateTime")),
+    )
+
+
+def _categorize_rain(value: float) -> str:
+    if value >= 30:
+        return "Black Rain"
+    if value >= 15:
+        return "Red Rain"
+    if value >= 5:
+        return "Amber Rain"
+    if value >= 1:
+        return "Showers"
+    return "Dry"
+
+
+def _categorize_aqhi(value: float) -> str:
+    if value >= 10:
+        return "Serious"
+    if value >= 7:
+        return "Very High"
+    if value >= 4:
+        return "High"
+    if value >= 3:
+        return "Moderate"
+    return "Low"
+
+
+def _parse_time(raw: str | None) -> datetime:
+    if not raw:
+        return datetime.now(timezone.utc)
+    for fmt in ISO_VARIANTS:
+        try:
+            return datetime.strptime(raw, fmt)
+        except (ValueError, TypeError):
+            continue
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return datetime.now(timezone.utc)
+
+
+def _get_payload(
+    config: Config, url: str, mock_path: Path, key: str | None = None
+) -> Dict[str, Any]:
+    if config.app.use_mock_data:
+        with mock_path.open("r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+    else:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        payload = response.json()
+    if key and isinstance(payload, dict):
+        if key in payload:
+            return payload[key]
+        nested = payload.get("data")
+        if isinstance(nested, dict) and key in nested:
+            return nested[key]
+    return payload
+
+
+__all__ = [
+    "collect_once",
+    "fetch_warning",
+    "fetch_rain",
+    "fetch_aqhi",
+    "fetch_traffic",
+]

--- a/hk_monitor/config.py
+++ b/hk_monitor/config.py
@@ -1,0 +1,132 @@
+"""Configuration helpers for the HK Conditions Monitor project."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+import os
+
+try:  # Python >=3.11
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - fallback for <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+@dataclass(slots=True)
+class AppConfig:
+    database_path: Path
+    poll_interval: int
+    rain_district: str
+    aqhi_station: str
+    traffic_region: str
+    use_mock_data: bool = False
+
+
+@dataclass(slots=True)
+class TelegramConfig:
+    bot_token: str
+    chat_id: str
+    test_mode: bool = False
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.bot_token and self.chat_id)
+
+
+@dataclass(slots=True)
+class ApiConfig:
+    warnings_url: str
+    rainfall_url: str
+    aqhi_url: str
+    traffic_url: str
+
+
+@dataclass(slots=True)
+class MockPaths:
+    warnings: Path
+    rainfall: Path
+    aqhi: Path
+    traffic: Path
+
+
+@dataclass(slots=True)
+class Config:
+    app: AppConfig
+    telegram: TelegramConfig
+    api: ApiConfig
+    mocks: MockPaths
+
+    @classmethod
+    def load(cls, path: Optional[str | os.PathLike[str]] = None) -> "Config":
+        """Load TOML configuration.
+
+        Args:
+            path: Optional path to a TOML file. Defaults to ``config.toml`` in
+                the current working directory.
+        """
+
+        config_path = Path(path or "config.toml")
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Configuration file '{config_path}' was not found. "
+                "Copy config.template.toml to config.toml and adjust the values."
+            )
+
+        with config_path.open("rb") as fh:
+            data = tomllib.load(fh)
+
+        return cls(
+            app=_parse_app_config(data.get("app", {}), config_path.parent),
+            telegram=_parse_telegram_config(data.get("telegram", {})),
+            api=_parse_api_config(data.get("api", {})),
+            mocks=_parse_mock_paths(data.get("mocks", {}), config_path.parent),
+        )
+
+
+def _parse_app_config(data: Dict[str, Any], base: Path) -> AppConfig:
+    return AppConfig(
+        database_path=(base / data.get("database_path", "final_project.db")).resolve(),
+        poll_interval=int(data.get("poll_interval", 300)),
+        rain_district=data.get("rain_district", "Central & Western"),
+        aqhi_station=data.get("aqhi_station", "Central/Western"),
+        traffic_region=data.get("traffic_region", "Hong Kong Island"),
+        use_mock_data=bool(data.get("use_mock_data", False)),
+    )
+
+
+def _parse_telegram_config(data: Dict[str, Any]) -> TelegramConfig:
+    return TelegramConfig(
+        bot_token=str(data.get("bot_token", "")),
+        chat_id=str(data.get("chat_id", "")),
+        test_mode=bool(data.get("test_mode", False)),
+    )
+
+
+def _parse_api_config(data: Dict[str, Any]) -> ApiConfig:
+    return ApiConfig(
+        warnings_url=str(data.get("warnings_url", "")),
+        rainfall_url=str(data.get("rainfall_url", "")),
+        aqhi_url=str(data.get("aqhi_url", "")),
+        traffic_url=str(data.get("traffic_url", "")),
+    )
+
+
+def _parse_mock_paths(data: Dict[str, Any], base: Path) -> MockPaths:
+    def _resolve(key: str, default: str) -> Path:
+        return (base / str(data.get(key, default))).resolve()
+
+    return MockPaths(
+        warnings=_resolve("warnings", "tests/data/warnings.json"),
+        rainfall=_resolve("rainfall", "tests/data/rainfall.json"),
+        aqhi=_resolve("aqhi", "tests/data/aqhi.json"),
+        traffic=_resolve("traffic", "tests/data/traffic.json"),
+    )
+
+
+__all__ = [
+    "AppConfig",
+    "TelegramConfig",
+    "ApiConfig",
+    "MockPaths",
+    "Config",
+]

--- a/hk_monitor/config.template.toml
+++ b/hk_monitor/config.template.toml
@@ -1,0 +1,25 @@
+[app]
+database_path = "./final_project.db"
+poll_interval = 300
+rain_district = "Central & Western"
+aqhi_station = "Central/Western"
+traffic_region = "Hong Kong Island"
+use_mock_data = true
+
+[telegram]
+bot_token = ""
+chat_id = ""
+
+test_mode = true
+
+[api]
+warnings_url = "https://data.weather.gov.hk/weatherAPI/opendata/weather.php?dataType=warnsum&lang=en"
+rainfall_url = "https://data.weather.gov.hk/weatherAPI/opendata/weather.php?dataType=rhrread&lang=en"
+aqhi_url = "https://data.weather.gov.hk/aq/data/aqhi.json"
+traffic_url = "https://resource.data.one.gov.hk/td/routesandregions/trafficnews_en.json"
+
+[mocks]
+warnings = "tests/data/warnings.json"
+rainfall = "tests/data/rainfall.json"
+aqhi = "tests/data/aqhi.json"
+traffic = "tests/data/traffic.json"

--- a/hk_monitor/db.py
+++ b/hk_monitor/db.py
@@ -1,0 +1,172 @@
+"""SQLite helpers for persisting snapshots."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+@dataclass(slots=True)
+class WarningRecord:
+    level: str
+    message: str
+    updated_at: datetime
+
+
+@dataclass(slots=True)
+class RainRecord:
+    district: str
+    intensity: str
+    updated_at: datetime
+
+
+@dataclass(slots=True)
+class AqhiRecord:
+    station: str
+    category: str
+    value: float
+    updated_at: datetime
+
+
+@dataclass(slots=True)
+class TrafficRecord:
+    severity: str
+    description: str
+    updated_at: datetime
+
+
+def init_db(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _create_tables(conn)
+    return conn
+
+
+def _create_tables(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    cur.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS warnings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            level TEXT NOT NULL,
+            message TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS rain (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            district TEXT NOT NULL,
+            intensity TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS aqhi (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            station TEXT NOT NULL,
+            category TEXT NOT NULL,
+            value REAL NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS traffic (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            severity TEXT NOT NULL,
+            description TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        """
+    )
+    conn.commit()
+
+
+def save_warning(conn: sqlite3.Connection, record: WarningRecord) -> None:
+    conn.execute(
+        "INSERT INTO warnings(level, message, updated_at) VALUES (?, ?, ?)",
+        (record.level, record.message, record.updated_at.strftime(ISO_FORMAT)),
+    )
+    conn.commit()
+
+
+def save_rain(conn: sqlite3.Connection, record: RainRecord) -> None:
+    conn.execute(
+        "INSERT INTO rain(district, intensity, updated_at) VALUES (?, ?, ?)",
+        (record.district, record.intensity, record.updated_at.strftime(ISO_FORMAT)),
+    )
+    conn.commit()
+
+
+def save_aqhi(conn: sqlite3.Connection, record: AqhiRecord) -> None:
+    conn.execute(
+        "INSERT INTO aqhi(station, category, value, updated_at) VALUES (?, ?, ?, ?)",
+        (
+            record.station,
+            record.category,
+            record.value,
+            record.updated_at.strftime(ISO_FORMAT),
+        ),
+    )
+    conn.commit()
+
+
+def save_traffic(conn: sqlite3.Connection, record: TrafficRecord) -> None:
+    conn.execute(
+        "INSERT INTO traffic(severity, description, updated_at) VALUES (?, ?, ?)",
+        (record.severity, record.description, record.updated_at.strftime(ISO_FORMAT)),
+    )
+    conn.commit()
+
+
+def _fetch_latest_two(conn: sqlite3.Connection, table: str) -> List[sqlite3.Row]:
+    cur = conn.execute(
+        f"SELECT * FROM {table} ORDER BY datetime(updated_at) DESC LIMIT 2"
+    )
+    return list(cur.fetchall())
+
+
+def get_latest(conn: sqlite3.Connection) -> Dict[str, Optional[sqlite3.Row]]:
+    return {
+        "warnings": _fetch_latest_row(conn, "warnings"),
+        "rain": _fetch_latest_row(conn, "rain"),
+        "aqhi": _fetch_latest_row(conn, "aqhi"),
+        "traffic": _fetch_latest_row(conn, "traffic"),
+    }
+
+
+def _fetch_latest_row(conn: sqlite3.Connection, table: str) -> Optional[sqlite3.Row]:
+    cur = conn.execute(f"SELECT * FROM {table} ORDER BY datetime(updated_at) DESC LIMIT 1")
+    return cur.fetchone()
+
+
+def get_last_two(conn: sqlite3.Connection, table: str) -> List[sqlite3.Row]:
+    return _fetch_latest_two(conn, table)
+
+
+@contextmanager
+def connect(db_path: Path) -> Iterator[sqlite3.Connection]:
+    conn = init_db(db_path)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "WarningRecord",
+    "RainRecord",
+    "AqhiRecord",
+    "TrafficRecord",
+    "init_db",
+    "save_warning",
+    "save_rain",
+    "save_aqhi",
+    "save_traffic",
+    "get_latest",
+    "get_last_two",
+    "connect",
+]

--- a/hk_monitor/requirements.txt
+++ b/hk_monitor/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.31.0
+pytest>=7.4.0
+# Needed for Python <3.11 when tomllib is unavailable
+tomli>=2.0.1; python_version < "3.11"

--- a/hk_monitor/tests/conftest.py
+++ b/hk_monitor/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT.parent))

--- a/hk_monitor/tests/data/aqhi.json
+++ b/hk_monitor/tests/data/aqhi.json
@@ -1,0 +1,9 @@
+{
+  "aqhi": [
+    {
+      "station": "Central/Western",
+      "aqhi": 6,
+      "time": "2024-07-01T12:00:00+08:00"
+    }
+  ]
+}

--- a/hk_monitor/tests/data/rainfall.json
+++ b/hk_monitor/tests/data/rainfall.json
@@ -1,0 +1,12 @@
+{
+  "updateTime": "2024-07-01T12:05:00+08:00",
+  "rainfall": {
+    "data": [
+      {
+        "place": "Central & Western",
+        "value": 12.3,
+        "recordTime": "2024-07-01T12:00:00+08:00"
+      }
+    ]
+  }
+}

--- a/hk_monitor/tests/data/traffic.json
+++ b/hk_monitor/tests/data/traffic.json
@@ -1,0 +1,10 @@
+{
+  "trafficnews": [
+    {
+      "region": "Hong Kong Island",
+      "severity": "Severe",
+      "content": "Accident near Central Ferry Pier causing congestion.",
+      "update_time": "2024-07-01T12:10:00+08:00"
+    }
+  ]
+}

--- a/hk_monitor/tests/data/warnings.json
+++ b/hk_monitor/tests/data/warnings.json
@@ -1,0 +1,9 @@
+{
+  "details": [
+    {
+      "warningStatementCode": "TC8",
+      "warningMessage": "Typhoon signal number 8 in force.",
+      "updateTime": "2024-07-01T12:00:00+08:00"
+    }
+  ]
+}

--- a/hk_monitor/tests/test_collectors.py
+++ b/hk_monitor/tests/test_collectors.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from hk_monitor import collector, db, alerts
+from hk_monitor.config import Config
+
+
+def _load_config() -> Config:
+    config_path = Path(__file__).resolve().parents[1] / "config.template.toml"
+    return Config.load(config_path)
+
+
+def test_fetch_warning_from_mock():
+    config = _load_config()
+    record = collector.fetch_warning(config)
+    assert record is not None
+    assert record.level == "TC8"
+
+
+def test_collect_once_persists(tmp_path):
+    config = _load_config()
+    config.app = replace(config.app, database_path=tmp_path / "test.db")
+    with db.connect(config.app.database_path) as conn:
+        snapshot = collector.collect_once(config, conn)
+        assert snapshot["warnings"] is not None
+        assert snapshot["rain"] is not None
+
+
+def test_change_detector_emits_alert_on_category_change(tmp_path, capsys):
+    config = _load_config()
+    config.app = replace(config.app, database_path=tmp_path / "test.db")
+    with db.connect(config.app.database_path) as conn:
+        older = db.WarningRecord(
+            level="TC3",
+            message="Strong wind expected",
+            updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        newer = db.WarningRecord(
+            level="TC8",
+            message="Typhoon signal 8",
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.save_warning(conn, older)
+        db.save_warning(conn, newer)
+        messenger = alerts.TelegramClient(token="", chat_id="", enabled=False, test_mode=True)
+        detector = alerts.ChangeDetector(conn, messenger)
+        detector.run()
+        captured = capsys.readouterr().out
+        assert "TC3" in captured
+        assert "TC8" in captured


### PR DESCRIPTION
## Summary
- add the `hk_monitor` package with configuration helpers, SQLite persistence, collectors, alerts, and CLI entry point for the HK Conditions Monitor plan
- ship a TOML template, README, requirements, and mock payloads so the app can run offline by default
- cover the critical flows with pytest-based smoke tests for collectors and alerting

## Testing
- `pytest hk_monitor/tests -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917371b78d8832f818d18fc3564ced4)