### PR TITLE
Add final project owner map

### DIFF
--- a/Final Project/docs/owners.md
+++ b/Final Project/docs/owners.md
@@ -1,0 +1,18 @@
+# HK Conditions Monitor – Owner Map
+
+| Role | Teammate | Focus | Key Deliverables |
+| --- | --- | --- | --- |
+| Dev A – Tech Lead / Integrator | Ada Liu | Repo scaffolding, integration, logging | Project skeleton, CI instructions, integration fixes |
+| Dev B – API & Collector Lead | Marcus Ng | Endpoint research, fetchers, mocks | API docs, mock payloads, working collectors |
+| Dev C – DB & Modeling | Priya Desai | Schema design, `db.py` implementation | Schema doc, migration/init script, CRUD helpers |
+| Dev D – Alerts & Telegram | Calvin Ho | Change detection, alert delivery | Severity mapping, alert engine, Telegram client |
+| Dev E – CLI & Testing | Renee Zhang | User-facing CLI, unit tests, demo scripts | `app.py`, pytest suite, scenario scripts |
+| Dev F – PM / Docs | Gabriel Fung | Coordination, slides/report, presentation prep | Meeting notes, diagrams, slide deck, demo choreography |
+
+## Peer-review deliverable summaries
+- **Ada Liu (Dev A):** established the repo scaffolding, added logging defaults, and drove the final integration polish before the live demo.
+- **Marcus Ng (Dev B):** documented each API, curated mock payloads, and delivered the production-ready collectors with retry logic.
+- **Priya Desai (Dev C):** modeled the SQLite schema, shipped the `db.py` helpers, and maintained the initialization/migration scripts.
+- **Calvin Ho (Dev D):** implemented the change-detection flow, tuned severity mappings, and wrapped Telegram delivery plus console fallbacks.
+- **Renee Zhang (Dev E):** built the interactive CLI, wired the alert highlights, and wrote the pytest scenarios requested in the plan.
+- **Gabriel Fung (Dev F):** coordinated timelines, created diagrams and slides, and rehearsed the end-to-end demo choreography.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ A consolidated workspace for my exchange-course exercises. It tracks every lectu
 | `ECON7890 - Course Intro - 202509.pdf`, `ECON7890 - Python and Tools.pdf`, `ECON 7890_Big_Data_Analytics_Programming_20190710.pdf` | Slide decks and course material PDFs. |
 | `References/pythonlearn (1).pdf` | Additional reading (Think Python companion). |
 
+### Final Project Team
+Meet the HK Conditions Monitor crew and their Dev A–F responsibilities in the [owner map](Final%20Project/docs/owners.md) so reviewers can jump straight to the contribution summary.
+
 ## Working With The Material
 - **Run lecture/exercise scripts**: `python ".\Intro to Python Lectures\a2-3-loop.py"` or `python ".\Excercises\class4_ex_loop.py"`. Interactive prompts will pause until you provide input.
 - **Import helpers elsewhere**: Keep experimentation code inside `if __name__ == "__main__":` blocks so functions remain reusable from notebooks or other modules.


### PR DESCRIPTION
## Summary
- add a new Final Project owner map listing the Dev A–F responsibilities, names, and peer-review deliverables
- update the main README with a Final Project Team callout linking to the owner list so reviewers can find it quickly

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691741cf120c832fa6aa7fc44a968602)