### PR TITLE
Add cached payload fallback for collectors

### DIFF
--- a/Final Project/hk_monitor/tests/data/last_aqhi.json
+++ b/Final Project/hk_monitor/tests/data/last_aqhi.json
@@ -1,0 +1,1 @@
+{"aqhi": [{"station": "Central/Western", "aqhi": 6, "time": "2024-07-01T12:00:00+08:00"}]}

--- a/Final Project/hk_monitor/tests/data/last_rainfall.json
+++ b/Final Project/hk_monitor/tests/data/last_rainfall.json
@@ -1,0 +1,1 @@
+{"updateTime": "2024-07-01T12:05:00+08:00", "rainfall": {"data": [{"place": "Central & Western", "value": 12.3, "recordTime": "2024-07-01T12:00:00+08:00"}]}}

--- a/Final Project/hk_monitor/tests/data/last_trafficnews.json
+++ b/Final Project/hk_monitor/tests/data/last_trafficnews.json
@@ -1,0 +1,1 @@
+{"trafficnews": [{"region": "Hong Kong Island", "severity": "Severe", "content": "Accident near Central Ferry Pier causing congestion.", "update_time": "2024-07-01T12:10:00+08:00"}]}

--- a/Final Project/hk_monitor/tests/data/last_warnings.json
+++ b/Final Project/hk_monitor/tests/data/last_warnings.json
@@ -1,0 +1,1 @@
+{"details": [{"warningStatementCode": "TC8", "warningMessage": "Typhoon signal number 8 in force.", "updateTime": "2024-07-01T12:00:00+08:00"}]}


### PR DESCRIPTION
## Summary
- add retry-aware HTTP fetching with cached payload fallbacks so collectors can persist data even when live APIs fail
- persist the last payload per metric on disk and teach tests to expect cached data usage
- add regression test covering HTTP failures that reuse cached payloads

## Testing
- `pytest 'Final Project/hk_monitor/tests/test_collectors.py'`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691741dff780832fbb57f2d2cfffa613)