### PR TITLE
Document readability redistribution plan

### DIFF
--- a/Final Project/docs/owners.md
+++ b/Final Project/docs/owners.md
@@ -1,18 +1,18 @@
 # HK Conditions Monitor – Owner Map
 
-| Role | Teammate | Focus | Key Deliverables |
+| Role | Teammate | Readability stream | Updated ownership focus |
 | --- | --- | --- | --- |
-| Dev A – Tech Lead / Integrator | Ada Liu | Repo scaffolding, integration, logging | Project skeleton, CI instructions, integration fixes |
-| Dev B – API & Collector Lead | Marcus Ng | Endpoint research, fetchers, mocks | API docs, mock payloads, working collectors |
-| Dev C – DB & Modeling | Priya Desai | Schema design, `db.py` implementation | Schema doc, migration/init script, CRUD helpers |
-| Dev D – Alerts & Console | Calvin Ho | Change detection, alert delivery | Severity mapping, alert engine, console messenger |
-| Dev E – CLI & Testing | Renee Zhang | User-facing CLI, unit tests, demo scripts | `app.py`, pytest suite, scenario scripts |
-| Dev F – PM / Docs | Gabriel Fung | Coordination, slides/report, presentation prep | Meeting notes, diagrams, slide deck, demo choreography |
+| Dev A – Tech Lead / Integrator | Ada Liu | Redistribution narrative | Curate the repo-root `README.md`, hk_monitor README, and config templates so the redistribution story and onboarding links stay in sync. |
+| Dev B – API & Collector Lead | Marcus Ng | Legible rewrite | Refactor all collectors plus `config.py` entry points until the dataflow reads like a narrated walkthrough with docstrings and helper functions. |
+| Dev C – DB & Modeling | Priya Desai | Legible rewrite | Apply the same tutorial-style cleanup to `db.py`, schema diagrams, and the state-machine notes that explain how collectors persist snapshots. |
+| Dev D – Alerts & Console | Calvin Ho | Heavy commenting & onboarding aids | Layer inline explanations across `alerts.py` and console glue code, plus record the alert escalation SOP referenced by the onboarding doc. |
+| Dev E – CLI & Testing | Renee Zhang | Heavy commenting & onboarding aids | Document the CLI/test interfaces, annotate pytest fixtures, and maintain the “day-one runbook” linking test commands to expected output. |
+| Dev F – PM / Docs | Gabriel Fung | Redistribution narrative | Thread the redistribution context into slides, diagrams, and doc issue templates so cross-team reviewers land on the same story. |
 
-## Peer-review deliverable summaries
-- **Ada Liu (Dev A):** established the repo scaffolding, added logging defaults, and drove the final integration polish before the live demo.
-- **Marcus Ng (Dev B):** documented each API, curated mock payloads, and delivered the production-ready collectors with retry logic.
-- **Priya Desai (Dev C):** modeled the SQLite schema, shipped the `db.py` helpers, and maintained the initialization/migration scripts.
-- **Calvin Ho (Dev D):** implemented the change-detection flow, tuned severity mappings, and built the console messenger/highlight plumbing.
-- **Renee Zhang (Dev E):** built the interactive CLI, wired the alert highlights, and wrote the pytest scenarios requested in the plan.
-- **Gabriel Fung (Dev F):** coordinated timelines, created diagrams and slides, and rehearsed the end-to-end demo choreography.
+## Day-to-day shifts under the readability push
+- **Ada Liu (Dev A):** splits her time between reviewing pull requests and ensuring every repo-touching doc points to the new readability plan; she now runs a daily link check to confirm config tables, owner map, and README anchors stay aligned.
+- **Marcus Ng (Dev B):** dedicates each workday to one collector module, rewriting long functions into smaller helpers, adding docstrings/tests, and pairing with Priya to keep terminology identical between fetchers and persistence.
+- **Priya Desai (Dev C):** focuses on demystifying `db.py`: she keeps an architecture sketch open during development, renames tables/fields for clarity, and narrates schema changes directly inside migration comments before handing them to Marcus.
+- **Calvin Ho (Dev D):** treats alerts as the onboarding classroom; he records inline commentary for every severity transition, authors SOP snippets that explain when humans intervene, and syncs them with Renee’s CLI notes.
+- **Renee Zhang (Dev E):** maintains the CLI walkthrough and pytest runbook; her daily routine now includes expanding fixture comments, embedding terminal transcripts, and verifying that newcomers can replay the tests without guessing flags.
+- **Gabriel Fung (Dev F):** stewards the narrative glue—he audits slides, doc templates, and meeting notes so they mirror the redistribution milestones and hosts twice-weekly check-ins to capture any onboarding blockers uncovered by the team.

--- a/Final Project/hk_monitor/README.md
+++ b/Final Project/hk_monitor/README.md
@@ -2,6 +2,8 @@
 
 This folder contains the reference implementation described in `Final Project/project-plan.md`.  It can run entirely on mock data for demos or switch to the real Hong Kong open-data APIs by setting `use_mock_data = false` in `config.toml`.
 
+> ✳️ **Readability redistribution:** Before touching code, skim the [Readability & Onboarding work package](../project-plan.md#9-readability--onboarding) so you know which teammate owns each redistribution, legible-rewrite, or heavy-commenting stream and how those expectations surface in this README.
+
 ## Getting started
 
 ```bash

--- a/Final Project/project-plan.md
+++ b/Final Project/project-plan.md
@@ -52,6 +52,10 @@ app.py CLI  →  prints latest tiles, accepts simple user input
    - Pytest/unit tests for parsers, category mapping, and change detection; scenario scripts: warning upgrade, AQHI spike, traffic incident.
 8. **Slides/Report**
    - Architecture/dataflow diagrams, screenshots (CLI views + alert transcripts), summary of libraries, lessons learned.
+9. **Readability & Onboarding**
+   - **Redistribution narrative**: Ensure `README.md`, `Final Project/hk_monitor/README.md`, and `docs/owners.md` all reference the same redistribution story so newcomers immediately learn why work moved into the three streams. **Acceptance criteria:** single-source definition of the redistribution goals, repo-root link to the detailed plan, and language that makes clear who owns each stream.
+   - **Legible rewrite**: Rework the collectors and adjacent modules (config loader, DB helpers) so every critical branch reads like a tutorial. **Acceptance criteria:** public functions start with short docstrings stating inputs/outputs, branching logic uses descriptive helper names rather than nested `if` chains, and the collectors compile under `pytest -q` with zero `TODO` or `FIXME` markers remaining.
+   - **Heavy commenting & onboarding aids**: Layer explanatory comments, diagrams, and SOP snippets wherever execution jumps across modules. **Acceptance criteria:** each module referenced in the onboarding doc contains section headers or block comments explaining the execution order, every config option has an inline explanation or table row describing defaults, and a new engineer can follow a linked “day one runbook” without asking for clarification.
 
 ## 4. Team Roles & Ownership
 | Role | Focus | Key Deliverables |


### PR DESCRIPTION
## Summary
- add a dedicated Readability & Onboarding work package that details redistribution, legible rewrite, and heavy commenting streams along with their acceptance criteria
- rewrite the owner map so every teammate is mapped to a readability stream and capture how their day-to-day work changes
- cross-link the hk_monitor README to the new plan section so the redistribution narrative is easy to find

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175724d800832f90bcad1edbb0582a)