### PR TITLE
Document pipeline steps across HK monitor modules

### DIFF
--- a/Final Project/hk_monitor/README.md
+++ b/Final Project/hk_monitor/README.md
@@ -14,6 +14,17 @@ cp config.template.toml config.toml
 
 Adjust the config to point to your preferred district/station.  No external tokens or services are required for the console-only workflow.
 
+## How to read this module
+
+The inline banners you will see throughout the code line up with the major legs of the pipeline:
+
+* **`collector.py` – "=== Snapshot collection entry points ===" / "=== Domain-specific helpers ===".** Start here to understand how each feed is downloaded, cached, and normalised.  The numbered "Step" comments describe the order in which weather warnings, rainfall, AQHI, and traffic records flow from HTTP helpers into SQLite.
+* **`app.py` – "=== Interactive console front-end ===" / "=== Menu discovery helpers ===".** This file shows how the CLI orchestrates a session: parsing args, refreshing snapshots, running change detection, and presenting pandas summaries.  Follow the "Step" annotations inside `DashboardSession.refresh` and `build_aqhi_history_report` to map the control flow back to the collector terminology.
+* **`db.py` – "=== Persistence layer ===".** The comments walk through connection setup, schema creation, and the `save_*` helpers, clarifying why datetimes are stored in ISO strings and how `get_last_two` feeds the alerting logic.
+* **`alerts.py` – "=== Alerting layer ===".** Read this after `db.py` to see how `_extract_category` and `ChangeDetector.run` interpret the latest rows and emit human-friendly messages via `ConsoleMessenger`.
+
+Together, these sections form a narrated tour: app.py (front-end) calls collector.py (snapshot collection), which persists rows via db.py (persistence layer) and finally alerts.py (alerting layer) highlights changes for the console dashboard.
+
 ## Interactive console dashboard
 
 The CLI now launches an interactive dashboard.  After selecting your configuration file you can:

--- a/Final Project/hk_monitor/alerts.py
+++ b/Final Project/hk_monitor/alerts.py
@@ -1,4 +1,11 @@
 """Change detection utilities for the HK Conditions Monitor."""
+
+# === Alerting layer ===
+
+# This module is the glue between storage and presentation: it inspects the
+# most recent rows, compares them to their predecessors, and emits alert
+# messages through messenger implementations.  The comments describe each stage
+# so the control flow is easy to follow.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -20,6 +27,10 @@ class AlertMessage:
     description: str
 
     def format(self) -> str:
+        """Return a printable, two-line alert message."""
+
+        # Keep the first line compact so console output stays readable; the
+        # second line contains the detailed description from the record.
         header = f"[{self.metric.upper()}] {self.previous} -> {self.current}"
         return f"{header}\n{self.description}"
 
@@ -59,6 +70,10 @@ class ChangeDetector:
         }
 
     def run(self) -> None:
+        """Compare the newest and previous rows per table and send alerts."""
+
+        # Step 1: iterate over each metric table so different feed types can be
+        # formatted independently.
         for table, formatter in self.table_config.items():
             rows = db.get_last_two(self.conn, table)
             if len(rows) < 2:
@@ -66,6 +81,8 @@ class ChangeDetector:
             previous, current = rows[1], rows[0]
             if _extract_category(previous) == _extract_category(current):
                 continue
+            # Step 2: lazily format the alert so expensive rendering only occurs
+            # when a real change has been detected.
             alert = formatter(current)
             alert.previous = _extract_category(previous)
             alert.current = _extract_category(current)
@@ -105,6 +122,10 @@ class ChangeDetector:
             description=row["description"],
         )
 def _extract_category(row: sqlite3.Row) -> str:
+    """Return a string that represents the severity/category for the row."""
+
+    # Step 1: prioritise semantic fields so warnings/rain/AQHI/traffic produce
+    # consistent alert headers regardless of table.
     for key in ("category", "level", "intensity", "severity"):
         if key in row.keys():
             return str(row[key])

--- a/Final Project/hk_monitor/collector.py
+++ b/Final Project/hk_monitor/collector.py
@@ -1,4 +1,11 @@
 """Data collectors for HK public data feeds."""
+
+# === Snapshot collection entry points ===
+
+# The comments in this module walk through the full "collector" leg of the
+# pipeline: we start by orchestrating a refresh, then branch into feed-specific
+# helpers, and finally drop into utility routines for parsing, caching, and
+# HTTP I/O.
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -24,22 +31,35 @@ def collect_once(
     config: Config, conn: sqlite3.Connection | None = None
 ) -> Dict[str, sqlite3.Row | None]:
     """Fetch all metrics once and persist them into SQLite."""
+
+    # Step 1: decide whether to open a fresh connection so the collector can be
+    # reused both by the CLI (which passes its own connection) and tests.
     if conn is None:
         from .db import connect
 
+        # Step 2: open a context-managed connection for one-shot collectors and
+        # immediately persist the fetched snapshot.
         with connect(config.app.database_path) as connection:
             _collect(config, connection)
             return db.get_latest(connection)
     else:
+        # Step 2b: reuse the provided connection to keep the surrounding
+        # transaction scope intact.
         _collect(config, conn)
         return db.get_latest(conn)
 
 
 def _collect(config: Config, conn: sqlite3.Connection) -> None:
+    """Run each feed collector in turn, writing rows when data is present."""
+
+    # Step 3: pull the weather warning feed first so dashboard users see the
+    # high-severity alerts immediately.
     warning_record = fetch_warning(config)
     if warning_record:
         db.save_warning(conn, warning_record)
 
+    # Step 4: hydrate rain, AQHI, then traffic data; every helper returns a
+    # domain record or ``None`` so empty feeds simply skip persistence.
     rain_record = fetch_rain(config)
     if rain_record:
         db.save_rain(conn, rain_record)
@@ -54,13 +74,21 @@ def _collect(config: Config, conn: sqlite3.Connection) -> None:
 
 
 def fetch_warning(config: Config) -> db.WarningRecord | None:
+    """Return the latest weather warning, if any."""
+
+    # Step 1: pull either the live payload or the mock JSON, caching the result
+    # keyed by "warnings" so subsequent runs can fall back to disk if needed.
     data = _get_payload(
         config, config.api.warnings_url, config.mocks.warnings, key="warnings"
     )
+    # Step 2: the API swaps between "details" and "warning" arrays, so probe
+    # both before bailing out.
     details = data.get("details") or data.get("warning") or []
     if not details:
         return None
     chosen = details[0]
+    # Step 3: prefer the entry-level timestamp but fall back to the dataset-wide
+    # update time so records always receive a concrete ``datetime``.
     timestamp = _parse_time(
         chosen.get("updateTime") or data.get("updateTime")
     )
@@ -72,19 +100,29 @@ def fetch_warning(config: Config) -> db.WarningRecord | None:
 
 
 def fetch_rain(config: Config) -> db.RainRecord | None:
+    """Return a rain record for the selected district."""
+
+    # Step 1: download the rainfall feed (or cached mock) under the "rainfall"
+    # cache key because some payloads pack multiple data types in one file.
     data = _get_payload(
         config, config.api.rainfall_url, config.mocks.rainfall, key="rainfall"
     )
+    # Step 2: normalize the payload, accommodating both "data" and nested
+    # "rainfall" -> "data" shapes so the subsequent search is stable.
     if "data" in data:
         rainfall_data = data.get("data", [])
     else:
         rainfall_data = (data.get("rainfall") or {}).get("data", [])
+    # Step 3: scan for the configured district so users can swap targets via the
+    # CLI without editing this function.
     district_entry = next(
         (row for row in rainfall_data if row.get("place") == config.app.rain_district),
         None,
     )
     if not district_entry:
         return None
+    # Step 4: cast to ``float`` because the API often ships strings; forcing a
+    # float here keeps comparison logic deterministic.
     value = float(district_entry.get("max", district_entry.get("value", 0)) or 0)
     return db.RainRecord(
         district=config.app.rain_district,
@@ -94,18 +132,26 @@ def fetch_rain(config: Config) -> db.RainRecord | None:
 
 
 def fetch_aqhi(config: Config) -> db.AqhiRecord | None:
+    """Return AQHI metrics for the configured station."""
+
+    # Step 1: normalize the AQHI payload into a list of stations.
     data = _get_payload(config, config.api.aqhi_url, config.mocks.aqhi, key="aqhi")
     if isinstance(data, list):
         stations = data
     else:
         stations = data.get("aqhi") or data.get("data") or []
+    # Step 2: pick the station requested by the dashboard.
     station_entry = next(
         (row for row in stations if row.get("station") == config.app.aqhi_station),
         None,
     )
     if not station_entry:
         return None
+    # Step 3: cast to float so downstream comparisons and pandas aggregations
+    # behave consistently even if the API returns strings.
     value = float(station_entry.get("aqhi", station_entry.get("value", 0)) or 0)
+    # Step 4: reuse explicit health-risk labels when provided, otherwise derive
+    # a text category from the numeric AQHI value.
     category = (
         station_entry.get("health_risk")
         or station_entry.get("category")
@@ -114,6 +160,8 @@ def fetch_aqhi(config: Config) -> db.AqhiRecord | None:
     publish_time = station_entry.get("publish_date") or station_entry.get("time")
     dataset_time = None
     if isinstance(data, dict):
+        # Having a dataset-level timestamp helps avoid "unknown" update times
+        # when the per-station payload omits it.
         dataset_time = data.get("publishDate") or data.get("updateTime")
     return db.AqhiRecord(
         station=config.app.aqhi_station,
@@ -124,6 +172,10 @@ def fetch_aqhi(config: Config) -> db.AqhiRecord | None:
 
 
 def fetch_traffic(config: Config) -> db.TrafficRecord | None:
+    """Return the latest traffic incident that matches the configured region."""
+
+    # Step 1: traffic uses XML upstream, so pass a parser callback that converts
+    # it to a list of incident dictionaries before caching.
     data = _get_payload(
         config,
         config.api.traffic_url,
@@ -143,6 +195,8 @@ def fetch_traffic(config: Config) -> db.TrafficRecord | None:
     def _matches(entry: Dict[str, Any]) -> bool:
         if not target:
             return True
+        # Glue all textual fields together and lower-case them so matching
+        # behaves like a fuzzy contains query over the user's region string.
         haystack = " ".join(
             filter(
                 None,
@@ -161,6 +215,8 @@ def fetch_traffic(config: Config) -> db.TrafficRecord | None:
     description = entry.get("content") or entry.get("summary") or "Traffic update"
     updated = entry.get("update_time")
     if not updated and isinstance(data, dict):
+        # Reuse the feed-level timestamp when individual items omit update_time
+        # so the dashboard always shows when data was last refreshed.
         updated = data.get("updateTime")
     return db.TrafficRecord(
         severity=severity.title(),
@@ -168,6 +224,8 @@ def fetch_traffic(config: Config) -> db.TrafficRecord | None:
         updated_at=_parse_time(updated),
     )
 
+
+# === Domain-specific helpers ===
 
 def _categorize_rain(value: float) -> str:
     if value >= 30:
@@ -194,6 +252,10 @@ def _categorize_aqhi(value: float) -> str:
 
 
 def _parse_time(raw: str | None) -> datetime:
+    """Convert the API timestamps into timezone-aware datetimes."""
+
+    # Step 1: timestamps are optional in almost every feed, so fall back to the
+    # current UTC time when nothing is supplied.
     if not raw:
         return datetime.now(timezone.utc)
     for fmt in ISO_VARIANTS:
@@ -214,13 +276,23 @@ def _get_payload(
     key: str | None = None,
     parser: Callable[[str], Any] | None = None,
 ) -> Any:
+    """Return either the mock payload or the live HTTP response, caching both."""
+
+    # Step 1: derive a deterministic cache path so live payloads can be reused
+    # whenever the network fails or is offline.
     cache_path = _cache_path(mock_path, key)
     if config.app.use_mock_data:
+        # Step 2a: load the mock payload from disk and refresh the cache so the
+        # most recent "live" data is always available for demos.
         payload = _load_from_disk(mock_path)
         _persist_cache(cache_path, payload)
     else:
+        # Step 2b: hit the real API, storing the parsed representation on disk
+        # so later runs can fall back gracefully.
         payload = _fetch_live_payload(url, cache_path, parser=parser)
     if key and isinstance(payload, dict):
+        # Step 3: many feeds wrap their data in either top-level keys or "data"
+        # namespaces; peel those layers automatically when a key is provided.
         if key in payload:
             return payload[key]
         nested = payload.get("data")
@@ -232,18 +304,28 @@ def _get_payload(
 def _fetch_live_payload(
     url: str, cache_path: Path, parser: Callable[[str], Any] | None = None
 ) -> Any:
+    """Hit the HTTP endpoint with retries and cache persistence."""
+
+    # Step 1: keep the last error around so we can re-raise it if caching also
+    # fails.
     last_error: Exception | None = None
     for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
+            # Step 2: issue the GET request with an explicit User-Agent and
+            # timeout so the public API operators can identify the client.
             response = requests.get(url, timeout=10, headers=HTTP_HEADERS)
             response.raise_for_status()
             if parser:
+                # XML feeds need a custom parser before caching; the parser
+                # returns a dict/list so downstream code sees JSON-like data.
                 payload = parser(response.text)
             else:
                 payload = response.json()
             _persist_cache(cache_path, payload)
             return payload
         except (requests.RequestException, ValueError, ET.ParseError) as exc:
+            # Step 3: retry a few times, logging warnings so operators can trace
+            # transient failures when diagnosing outages.
             last_error = exc
             LOGGER.warning(
                 "Attempt %s/%s to fetch %s failed: %s",
@@ -254,6 +336,8 @@ def _fetch_live_payload(
             )
     cached = _load_cached_payload(cache_path)
     if cached is not None:
+        # Step 4: prefer a stale-but-valid cached payload to raising an error;
+        # the CLI already highlights when data is old.
         LOGGER.info("Using cached payload from %s for %s", cache_path, url)
         return cached
     if last_error:
@@ -262,12 +346,17 @@ def _fetch_live_payload(
 
 
 def _cache_path(mock_path: Path, key: str | None) -> Path:
+    """Build a filesystem-friendly cache filename derived from the payload."""
+
+    # Step 1: prefer domain-specific keys so caches remain readable when
+    # multiple endpoints share the same mock folder.
     identifier = (key or mock_path.stem or "payload").strip() or "payload"
     safe = "".join(c if c.isalnum() or c in {"-", "_"} else "_" for c in identifier)
     return mock_path.parent / f"last_{safe}.json"
 
 
 def _persist_cache(path: Path, payload: Any) -> None:
+    """Write the latest payload to disk for offline replays."""
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as fh:
@@ -277,6 +366,7 @@ def _persist_cache(path: Path, payload: Any) -> None:
 
 
 def _load_cached_payload(path: Path) -> Any | None:
+    """Load the previously cached payload, if the file is still valid."""
     try:
         return _load_from_disk(path)
     except FileNotFoundError:
@@ -287,11 +377,13 @@ def _load_cached_payload(path: Path) -> Any | None:
 
 
 def _load_from_disk(path: Path) -> Any:
+    """Convenience helper for reading JSON mock files."""
     with path.open("r", encoding="utf-8") as fh:
         return json.load(fh)
 
 
 def _parse_traffic_xml(text: str) -> Dict[str, Any]:
+    """Convert the Transport Department XML into JSON-like dictionaries."""
     root = ET.fromstring(text)
     incidents = []
     for message in root.findall(".//message"):


### PR DESCRIPTION
## Summary
- add tutorial-style banners and step-by-step annotations to the collector, app, database, and alerting modules so each logical phase of the pipeline is narrated in-line
- explain why casts, caching, and selections occur in specific places to aid future readers and demos
- introduce a "How to read this module" section in the README that maps the new commentary to the broader pipeline

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691757397674832f91410f38f0fc9193)