### PR TITLE
Improve documentation for students

### DIFF
--- a/Excercises/class2_ex_function.py
+++ b/Excercises/class2_ex_function.py
@@ -1,3 +1,14 @@
+"""Class 2 warm-up: financial helper functions with clear documentation.
+
+Each function mirrors the auto-grader contract from the lecture slides but now
+ships with docstrings and inline commentary so students can quickly review the
+formula, expected units, and return type.  Sample invocations live in the
+``if __name__ == "__main__"`` block at the end of the file so importing this
+module in a notebook does not spam the console.
+"""
+
+import math
+
 # Class Exercise 2: Financial Functions
 # Complete the functions below EXACTLY as specified.
 # ⚠️ AUTO-GRADER CRITICAL WARNING ⚠️
@@ -5,86 +16,112 @@
 # - Incorrect return types/formats will result in 0 marks for that question
 # - Comments are ignored by Python and auto-grader (you can add your own)
 
-import math
 
 # Example Solution Format ------------------------------------------------------
 # Original question template
 def square_area(length):
+    """Return the area of a square to demonstrate the expected pattern."""
+
     # Formula: area = length^2
     # Sample input: 5 → Output: 25
-    return 
+    return
+
 
 # What you need to do is to change the function content to be like this:
 # You can keep or add comments. But reminder not to change the function name
 # and not to change the amount of input parameters.
 # You must return the result instead of printing it.
 def square_area(length):
-    return length ** 2
+    """Final answer for the worked example above (length squared)."""
+
+    return length**2
 
 # Your Tasks -------------------------------------------------------------------
 # Question 1 - Calculate circle circumference
 def circle_circumference(radius):
+    """Return the circumference of a circle using 2 * π * radius."""
+
     # Formula: 2 * π * radius (use math.pi)
     # Sample input: 3 → Output: ~18.8495559
     # Return type: float
     return 2 * math.pi * radius
 
-print(circle_circumference(3))  # Example usage
-
 # Question 2 - Calculate area of triangle
 def triangle_area(base, height):
+    """Return the area of a triangle given base and height."""
+
     # Formula: (base * height) / 2
     # Sample input: 4, 5 → Output: 10.0
     # Return type: float
     return (base * height) / 2
-print(triangle_area(4, 5))  # Example usage
 
 # Question 3 - Profit/loss percentage (DECIMAL FORMAT)
 def profit_loss_percentage(buy_price, sell_price):
+    """Return the gain/loss ratio as a decimal (e.g., 0.032 == 3.2%)."""
+
     # Formula: (sell_price - buy_price)/buy_price
     # Return: decimal (NOT percentage), e.g., 3.2% → 0.032
     # Sample input: 100, 103.2 → Output: 0.032
     # Return type: float
     return (sell_price - buy_price) / buy_price
-print(profit_loss_percentage(100, 103.2))  # Example usage
 
 # Question 4 - Calculate BMI (height in CENTIMETERS)
 def bmi(weight, height):
+    """Return Body Mass Index using kilograms and centimetres."""
+
     # Formula: weight(kg) / (height(m))²
     # Convert height to meters: height/100
     # Sample input: 70, 175 → Output: ~22.857
     # Return type: float
-    return weight / ( (height / 100) ** 2 )
-print(bmi(70, 175))  # Example usage
+    return weight / ((height / 100) ** 2)
 
 # Question 5 - Calculate Simple Interest (rate is DECIMAL)
 def simple_interest(principal, rate, year):
+    """Return interest earned with the simple-interest formula."""
+
     # Formula: principal * rate * year
     # Sample input: 1000, 0.05 (which means 5%), 3 → Output: 150.0
     # Return type: float
     return principal * rate * year
-print(simple_interest(1000, 0.05, 3))  # Example usage
 
 # Question 6 - Currency conversion
 def convert_currency(amount, exchange_rate):
+    """Return the converted currency amount using the given rate."""
+
     # Formula: amount * exchange_rate
     # Sample input: 10000, 0.13 → Output: 1300.0
     # Return type: float
     return amount * exchange_rate
-print(convert_currency(10000, 0.13))  # Example usage
 
 # Question 7 - Calculate P/E ratio
 def pe_ratio(price_per_share, earnings_per_share):
+    """Return the price-to-earnings ratio for a single stock."""
+
     # Formula: price_per_share / earnings_per_share
     # Sample input: 150, 7.5 → Output: 20.0
     # Return type: float
     return price_per_share / earnings_per_share
-print(pe_ratio(150, 7.5))  # Example usage
 
 # Question 8 - Calculate crypto portfolio value
 def crypto_portfolio_value(coin_amount, current_price):
+    """Return the notional portfolio value in fiat currency."""
+
     # Formula: coin_amount * current_price
     # Sample input: 3.5, 28000 → Output: 98000.0
     # Return type: float
     return coin_amount * current_price
-print(crypto_portfolio_value(3.5, 28000))  # Example usage
+
+
+if __name__ == "__main__":
+    # Demonstrate each helper with the sample inputs referenced above.  Keeping
+    # these prints behind the main-guard ensures the auto-grader imports the
+    # module without running side effects, while still letting students run the
+    # file directly for quick sanity checks.
+    print(circle_circumference(3))
+    print(triangle_area(4, 5))
+    print(profit_loss_percentage(100, 103.2))
+    print(bmi(70, 175))
+    print(simple_interest(1000, 0.05, 3))
+    print(convert_currency(10000, 0.13))
+    print(pe_ratio(150, 7.5))
+    print(crypto_portfolio_value(3.5, 28000))

--- a/Final Project/docs/architecture.md
+++ b/Final Project/docs/architecture.md
@@ -34,6 +34,13 @@ graph TD
 - Each run persists the latest snapshot and reuses SQLite both for persistence and change detection.
 - Alerts feed the CLI highlights and console transcript so presenters can narrate incidents directly from the terminal.
 
+## Module responsibilities & entry points
+- **`hk_monitor.app`** – The `DashboardSession` class (see `refresh` and `_detect_alerts`) owns the loop shown above: parse CLI flags, collect data, query SQLite for the latest rows, then print and annotate the snapshot.  `build_aqhi_history_report` bridges the persistence layer with the ASCII table rendered in the console.
+- **`hk_monitor.collector`** – `collect_once` coordinates `fetch_warning`, `fetch_rain`, `fetch_aqhi`, and `fetch_traffic`.  Each helper converts vendor-specific payloads into the dataclasses exported by `db.py`, handling caching and mock/live toggles along the way.
+- **`hk_monitor.db`** – `init_db` and the `save_*`/`get_last_two` helpers are the only modules that talk directly to SQLite.  Timestamps are stored using the shared `ISO_FORMAT` constant so alerts and reports can compare values lexicographically without reparsing.
+- **`hk_monitor.alerts`** – `ChangeDetector.run` is the alerting engine.  It reads the newest two rows for each table via `db.get_last_two`, compares their derived category (see `_extract_category`), and emits `AlertMessage` objects through a `Messenger` implementation such as `ConsoleMessenger`.
+- **Tests (`hk_monitor/tests`)** – Scenario tests such as `test_scenarios.py` encode the “warning upgrade / AQHI spike / traffic incident” narratives referenced in the project plan.  Treat them as executable documentation when stepping through the architecture diagram.
+
 ## Deployment view
 - Local execution: `python -m hk_monitor.app` with mock data.
 - Production: run collectors via cron/systemd and rely on the CLI for on-demand tiles and alert transcripts.

--- a/Final Project/docs/assets/alert-log.txt
+++ b/Final Project/docs/assets/alert-log.txt
@@ -1,2 +1,6 @@
+# Sample console transcript used in presentation rehearsals.
+# Format mirrors the `ConsoleMessenger` output so teammates can paste new
+# dry-run alerts here without re-recording audio.  New entries should keep the
+# two-line structure: a timestamped header followed by the human description.
 2025-11-14 14:57:07,751 [INFO] hk_monitor.alerts - [DRY RUN] [WARNINGS] TC8 -> RED
 Red rainstorm warning upgraded.

--- a/Final Project/hk_monitor/README.md
+++ b/Final Project/hk_monitor/README.md
@@ -27,6 +27,18 @@ The inline banners you will see throughout the code line up with the major legs 
 
 Together, these sections form a narrated tour: app.py (front-end) calls collector.py (snapshot collection), which persists rows via db.py (persistence layer) and finally alerts.py (alerting layer) highlights changes for the console dashboard.
 
+### Code map for students
+
+| Area | What to inspect | Why it matters |
+| --- | --- | --- |
+| Interactive session | `DashboardSession` and `MenuController` inside `app.py` | Shows how CLI arguments, refresh loops, and menu-driven overrides drive the rest of the system.  Comments labelled "Step" mirror the flow shown in `docs/architecture.md`. |
+| Snapshot collection | `collector.collect_once` and feed-specific helpers (`fetch_warning`, `fetch_rain`, `fetch_aqhi`, `fetch_traffic`) | Each helper documents the payload shape, fallback logic, and normalisation into the dataclasses from `db.py`.  Use these notes when swapping from mock JSON to live APIs. |
+| Persistence | `db.py` dataclasses plus `save_*`/`get_latest` functions | Explains how rows are stored as ISO strings and how `get_last_two` powers change detection; the docstrings double as a schema cheat sheet. |
+| Alerts & history | `alerts.ChangeDetector` and `app.build_aqhi_history_report` | Demonstrates how category comparisons trigger alerts and how pandas-style summaries are rendered in plain text for demos. |
+| Tests | `tests/test_collectors.py`, `tests/test_scenarios.py`, `tests/test_history_summary.py` | Provide executable documentation.  Each test has docstrings/comments describing the scenario so students can trace inputs → stored rows → alert output. |
+
+Use the table above as a scavenger hunt: pick an area, read the referenced code plus its inline explanations, then run `pytest -k <topic>` to reinforce the concept.
+
 ## Interactive console dashboard
 
 The CLI now launches an interactive dashboard.  After selecting your configuration file you can:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A consolidated workspace for my exchange-course exercises. It tracks every lectu
 ### Final deliverables & references
 | Path | Purpose |
 | --- | --- |
+| `Final Project/hk_monitor/` | Final code for the HK Conditions Monitor (CLI dashboard, collectors, SQLite helpers, alerting tests). See its README for setup and module-by-module walkthroughs. |
 | `Final Project/ECON7890 Project 2025 Fall.pdf` | Final project write-up. |
 | `ECON7890 - Course Intro - 202509.pdf`, `ECON7890 - Python and Tools.pdf`, `ECON 7890_Big_Data_Analytics_Programming_20190710.pdf` | Slide decks and course material PDFs. |
 | `References/pythonlearn (1).pdf` | Additional reading (Think Python companion). |


### PR DESCRIPTION
## Summary
- add inline docstrings and a safe sample runner to `Excercises/class2_ex_function.py` so students can see the formulas without triggering prints on import
- expand the HK Conditions Monitor docs (repo root README, module README, architecture notes, alert log) to describe how each file maps to the pipeline and demos

## Testing
- `cd "Final Project/hk_monitor" && pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176a236ff0832fbb4f62ce1a4e698f)