### PR TITLE
Simplify menu actions and record storage

### DIFF
--- a/Final Project/hk_monitor/app.py
+++ b/Final Project/hk_monitor/app.py
@@ -16,7 +16,6 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set
 
 try:
@@ -82,7 +81,7 @@ def main() -> None:
         dashboard.run(skip_initial_refresh=args.collect)
 
 
-class MenuAction(Enum):
+class MenuAction:
     """Possible outcomes from the menu prompt."""
 
     REFRESH = "refresh"
@@ -119,9 +118,9 @@ class DashboardSession:
                 else:
                     skip_refresh = False
                 action = self.menu.prompt()
-                if action is MenuAction.EXIT:
+                if action == MenuAction.EXIT:
                     break
-                if action is MenuAction.REFRESH:
+                if action == MenuAction.REFRESH:
                     continue
                 # Defensive clamp so a student entering "-5" never crashes the loop.
                 wait_seconds = max(0, int(self.config.app.poll_interval))
@@ -179,7 +178,7 @@ class MenuController:
         """Reload menu choices from the latest available payloads."""
         self._options = _load_menu_options(self.config)
 
-    def prompt(self) -> MenuAction:
+    def prompt(self) -> str:
         """Run the input loop and return the chosen dashboard action."""
 
         menu_text = (

--- a/Final Project/hk_monitor/tests/test_collectors.py
+++ b/Final Project/hk_monitor/tests/test_collectors.py
@@ -39,11 +39,11 @@ def test_change_detector_emits_alert_on_category_change(tmp_path):
     config = _load_config()
     config.app = replace(config.app, database_path=tmp_path / "test.db")
     with db.connect(config.app.database_path) as conn:
-        older = db.WarningRecord(
-            level="TC3",
-            message="Strong wind expected",
-            updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
-        )
+        older = {
+            "level": "TC3",
+            "message": "Strong wind expected",
+            "updated_at": datetime.now(timezone.utc) - timedelta(hours=1),
+        }
         newer = db.WarningRecord(
             level="TC8",
             message="Typhoon signal 8",


### PR DESCRIPTION
## Summary
- replace the menu action enum with simple string constants and adjust dashboard comparisons
- convert alert and persistence record models to lightweight classes that also accept dict inputs
- update change-detection utilities and tests to work with the simplified structures and signatures

## Testing
- python -m pytest tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691edc732330832f9d946ae5830eb336)